### PR TITLE
Add unindexed Package

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Supported by: [GuardRails.io](https://github.com/apps/guardrails)
 - [gorilla/csrf](https://github.com/gorilla/csrf) - Provides Cross Site Request Forgery (CSRF) prevention middleware for Go web applications & services.
 - [gorilla/securecookie](https://github.com/gorilla/securecookie) - Encodes and decodes authenticated and optionally encrypted cookie values for Go web applications.
 - [secure](https://github.com/unrolled/secure) -  Secure is an HTTP middleware for Go that facilitates most of your security needs for web applications.
+- [unindexed](https://github.com/jordan-wright/unindexed) - A drop-in replacement for `http.Dir` which disables directory indexing.
 
 
 ## Libraries


### PR DESCRIPTION
By default, the `http.Dir` HTTP filesystem supports directory indexing. The `unindexed` package provides a drop-in replacement that disables directory indexing, preventing the information disclosure of sensitive files in the webroot.